### PR TITLE
Report coverage to Codacy and add badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     - rvm: 2.1.9
       env: CHECK=test
     - rvm: 2.4.2
-      env: CHECK=test_with_coveralls
+      env: CHECK=test_and_report_coverage
 branches:
   only:
     - master

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Build Status](https://img.shields.io/travis/voxpupuli/puppet_webhook.svg)](https://travis-ci.org/voxpupuli/puppet_webhook)
 [![Gem Version](https://img.shields.io/gem/v/puppet_webhook.svg)](https://rubygems.org/gems/puppet_webhook)
 [![Gem Downloads](https://img.shields.io/gem/dt/puppet_webhook.svg)](https://rubygems.org/gems/puppet_webhook)
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/f73823762ec947889866c63c4ea47540)](https://www.codacy.com/app/VoxPupuli/puppet_webhook?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=voxpupuli/puppet_webhook&amp;utm_campaign=Badge_Grade)
 [![Coverage Status](https://coveralls.io/repos/github/voxpupuli/puppet_webhook/badge.svg?branch=master)](https://coveralls.io/github/voxpupuli/puppet_webhook?branch=master)
 [![Dependency Status](https://gemnasium.com/badges/github.com/voxpupuli/puppet_webhook.svg)](https://gemnasium.com/github.com/voxpupuli/puppet_webhook)
 

--- a/Rakefile
+++ b/Rakefile
@@ -8,8 +8,11 @@ desc 'Run all tests'
 task test: %i[rubocop spec]
 
 require 'coveralls/rake/task'
-desc 'Run all tests and report to coveralls'
-task test_with_coveralls: [:test] do
+require 'codacy-coverage'
+desc 'Run all tests and report to coverage tools'
+task test_and_report_coverage: [:test] do
   Coveralls::RakeTask.new
   Rake::Task['coveralls:push'].invoke
+  result = ::SimpleCov::ResultMerger.merged_result
+  Codacy::Formatter.new.format result
 end

--- a/puppet_webhook.gemspec
+++ b/puppet_webhook.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'sinatra-contrib'
   spec.add_runtime_dependency 'slack-notifier'
   spec.add_runtime_dependency 'webrick'
+  spec.add_development_dependency 'codacy-coverage'
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'github_changelog_generator'
   spec.add_development_dependency 'rack-test'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,10 +8,11 @@ SimpleCov.formatters = [
   SimpleCov::Formatter::Console
 ]
 SimpleCov.start do
-  track_files 'lib/**/*.rb'
-  add_filter '/spec'
-  add_filter '/vendor'
-  add_filter '/.vendor'
+  add_filter '.gems'
+  add_filter 'spec'
+  add_filter 'pkg'
+  add_filter 'vendor'
+  add_filter '.vendor'
 end
 
 ENV['RACK_ENV'] = 'test'


### PR DESCRIPTION
Coverage is only reported after successful builds by travis on master.
There doesn't seem to be a way of getting the reports reports to send
from PRs.