### PR TITLE
Add tests to validate posts to the module route 

### DIFF
--- a/lib/puppet_webhook.rb
+++ b/lib/puppet_webhook.rb
@@ -52,6 +52,8 @@ class PuppetWebhook < Sinatra::Base # rubocop:disable Style/Documentation
   set :command_prefix, 'umask 0022;' unless settings.respond_to? :command_prefix=
   set :github_secret, nil unless settings.respond_to? :github_secret=
   set :repository_events, nil unless settings.respond_to? :respository_events=
+  set :user, 'puppet' unless settings.respond_to? :user=
+  set :pass, 'puppet' unless settings.respond_to? :pass=
 
   # Deprecated Settings
   set :slack_webhook, false unless settings.respond_to? :slack_webhook=

--- a/puppet_webhook.gemspec
+++ b/puppet_webhook.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'github_changelog_generator'
   spec.add_development_dependency 'mcollective-client'
+  spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rack-test'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'

--- a/spec/fixtures/github/update-headers.json
+++ b/spec/fixtures/github/update-headers.json
@@ -1,3 +1,4 @@
 {
-  "HTTP_X_GITHUB_EVENT": "push"
+  "HTTP_X_GITHUB_EVENT": "push",
+  "Content-Type": "application/json"
 }

--- a/spec/unit/puppet_webhook_spec.rb
+++ b/spec/unit/puppet_webhook_spec.rb
@@ -6,4 +6,19 @@ describe PuppetWebhook do
     expect(last_response).to be_ok
     expect(last_response.body).to eq('{"status":"success","message":"running"}')
   end
+
+  it 'index returns 404 error message' do
+    get '/'
+    expect(last_response).not_to be_ok
+    expect(last_response.body).to eq("You shall not pass! (page not found)\n")
+  end
+
+  # it '/module returns data' do
+  #   stub_const('LOGGER', Logger.new(STDOUT))
+  #   header 'Content-Type', "application-json"
+  #   header 'HTTP_X_GITLAB_EVENT', "Push Hook"
+  #   header 'Authorization', "Basic #{Base64::encode64('puppet:puppet')}"
+  #   post '/module', body: read_fixture('gitlab/update.json')
+  #   puts last_response.body
+  # end
 end

--- a/spec/unit/puppet_webhook_spec.rb
+++ b/spec/unit/puppet_webhook_spec.rb
@@ -13,12 +13,12 @@ describe PuppetWebhook do
     expect(last_response.body).to eq("You shall not pass! (page not found)\n")
   end
 
-  it '/module returns data' do
-    stub_const('LOGGER', Logger.new(STDOUT))
-    header 'Content-Type', "application-json"
-    header 'HTTP_X_GITLAB_EVENT', "Push Hook"
-    header 'Authorization', "Basic #{Base64::encode64('puppet:puppet')}"
-    post '/module', body: read_fixture('gitlab/update.json')
-    puts last_response.body
-  end
+  # it '/module returns data' do
+  #   stub_const('LOGGER', Logger.new(STDOUT))
+  #   header 'Content-Type', "application-json"
+  #   header 'HTTP_X_GITLAB_EVENT', "Push Hook"
+  #   header 'Authorization', "Basic #{Base64::encode64('puppet:puppet')}"
+  #   post '/module', body: read_fixture('gitlab/update.json')
+  #   puts last_response.body
+  # end
 end

--- a/spec/unit/puppet_webhook_spec.rb
+++ b/spec/unit/puppet_webhook_spec.rb
@@ -13,12 +13,12 @@ describe PuppetWebhook do
     expect(last_response.body).to eq("You shall not pass! (page not found)\n")
   end
 
-  # it '/module returns data' do
-  #   stub_const('LOGGER', Logger.new(STDOUT))
-  #   header 'Content-Type', "application-json"
-  #   header 'HTTP_X_GITLAB_EVENT', "Push Hook"
-  #   header 'Authorization', "Basic #{Base64::encode64('puppet:puppet')}"
-  #   post '/module', body: read_fixture('gitlab/update.json')
-  #   puts last_response.body
-  # end
+  it '/module returns data' do
+    stub_const('LOGGER', Logger.new(STDOUT))
+    header 'Content-Type', "application-json"
+    header 'HTTP_X_GITLAB_EVENT', "Push Hook"
+    header 'Authorization', "Basic #{Base64::encode64('puppet:puppet')}"
+    post '/module', body: read_fixture('gitlab/update.json')
+    puts last_response.body
+  end
 end


### PR DESCRIPTION
These tests will test the get routes for `/` and `/heartbeat`. For now, I will be redirecting my focus on testing the helper methods rather than the post routes first. Those methods are more important to test rather than the post routes. 

Tests for the post routes will resume after the helpers are tested.