### PR TITLE
Update config options and docs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,3 +28,6 @@ Metrics/ModuleLength:
 Style/RegexpLiteral:
   EnforcedStyle: percent_r
   Enabled: True
+
+Layout/EmptyLinesAroundArguments:
+  Enabled: False

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ dist: trusty
 before_install:
   - bundle -v
   - rm Gemfile.lock || true
-  - gem update --system
-  - gem update bundler
+  - gem install bundler -v 1.16.0
   - bundle -v
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/README.md
+++ b/README.md
@@ -15,11 +15,6 @@
 puppet_webhook is a Sinatra-based application receiving REST-based calls to trigger Puppet and r10k-related tasks such as:
 
 * Webhooks from Source Code systems to trigger r10k environment and module deploys
-* REST calls from systems to trigger Puppet Decommissions such as:
-    * `puppet node clean`
-    * `puppet cert clean`
-    * `puppet cert revoke`
-    * etc.
 * Send notifications via Slack
 
 ## Prerequisites
@@ -42,12 +37,6 @@ NOTE: RPM, DEB, and Arch packages are planned for future releases.
 
 ### Running puppet_webhook
 
-Once installed, you can run the application by simply executing the `puppet_webhook` binary.
-
-This binary will default to using the bundled configuration files and run in a non-daemon mode. This mode is useful for debugging purposes, but it probably not ideal for production use.
-You can also set the `server_type` option in `/etc/puppet_webhook/server.yml` to `daemon` to run the application in the background. By default the application will log to `/var/log/puppet_webhook/access.log`.
-
-NOTE: During the Prerelease stage, the `/etc/puppet_webhook` and `/var/log/puppet_webhook` directories need to be manually created. This will be fixed in for General Availability.
 
 ### Configuring puppet_webhook
 

--- a/README.md
+++ b/README.md
@@ -77,9 +77,13 @@ Any configuration option is placed in `/etc/puppet_webhook/server.yml` or `/etc/
 
 
 #### Server Configuration File
-The Server configuration file is a YAML formatted file with file extension `.yml` and
+The Server configuration file is a YAML formatted file with file extension `.yml` and defined with the `-c` or `--configfile`
+command line option. These settings are exclusively for setting server configs and currently will override any command line settings
+passed.
 
-#### server.yml
+When using the default systemd unit file or SysVInit service file, the server configuration file will default to `/etc/puppet_webhook/server.yml` (Not implemented yet).
+
+##### Options
 
 #####`server_type`
 Determines if the Webrick server should run in Simple or Daemon mode.     
@@ -88,25 +92,15 @@ Determines if the Webrick server should run in Simple or Daemon mode.
 
 ##### `logfile`
 Location to write the log file to.
-* Default: `/var/log/puppet_webhook/access.log`
+* Default: `/var/log/puppet_webhook`
+
+##### `loglevel`
+Define the logging level.
+* Default: `WARN`
 
 ##### `pidfile`
 Location of the application's PID file
 * Default: `/var/run/puppet_webhook/webhook.pid`
-
-##### `lockfile`
-Location of the application's Lockfile
-* Default: `/var/run/puppet_webhook/webhook.lock`
-
-##### `approot`
-Location of the Root of the application's directory
-* Default: `./`
-NOTE: Currently unused
-
-##### `bind_address`
-IPv4 Address to bind to.
-* MUST BE VALID IPv4 ADDRESS.
-* Default: `0.0.0.0`
 
 ##### `port`
 Port number to bind to.
@@ -118,42 +112,36 @@ Whether or not to enable SSL communication.
 * Valid options: [ `true`, `false` ]
 * Default: `false`
 
-##### `verify_ssl`
+##### `ssl_verify`
 Whether or not to verify the SSL CA/Peer on the certifcate. Set to false if using a self-signed certificate and the CA is not installed locally.
 * Valid options: [ `true`, `false` ]
 * Default: `false`
 
-##### `public_key_path`
+##### `ssl_cert`
 Path to the public SSL certificate for puppet_webhook. REQUIRED IF `ssl_enable` IS SET TO `true`
-* Default: ''
 
-##### `private_key_path`
+##### `ssl_key`
 Path to the SSL Private Key for puppet_webhook. REQUIRED IF `ssl_enable` IS SET TO `true`
-* Default: ''
 
-##### `command_prefix`
-Command to prefix the r10k and puppet commands with when executed.
-* Default: 'umask 0022;'
+#### Application Configuration File
+This file stores the configuration for the Application itself. A default configuration file is included in the `APP_ROOT/config/app.yml`.
 
-#### app.yml
+The SystemD unit and SysVInit service files will use `/etc/puppet_webhook/app.yml` by default (Not implemented yet).
 
-##### `enable_mutex_lock`
-Force all requests to syncronize on a mutex lock, ensuring that only a single request is processed at a time.
-* Valid options: [ `true`, `false` ]
-* Default: `false`
+Currently, the above two locations are the only valid locations for the app.yml file. Like the Server Config, it must be a .yml file in YAML format.
 
-##### `user`
-User for which the sending application must authenticate with.
-* Default: `puppet`
-
-##### `pass`
-Password for which the sending application must authenticate with.
-* Default: `puppet`
+##### Options
 
 ##### `protected`
 Whether or not to require authentication when sending to puppet_webhook.
 * Valid options: [ `true`, `false` ]
-* Default: `true`
+* Default: `false`
+
+##### `user`
+User for which the sending application must authenticate with. Required if `protected` is true.
+
+##### `pass`
+Password for which the sending application must authenticate with. Require if `protected` is true.
 
 ##### client_cfg
 Mcollective client configuration file.
@@ -169,27 +157,19 @@ Whether or not to execute MCollective via Ruby Client Library or not. REQUIRES M
 * Valid options: [ `true`, `false` ]
 * Default: `false`
 
-##### discovery_timeout
-MCollective Ruby discovery timeout. REQUIRES `use_mco_ruby` TO BE `true`.
-* Default: `'10'`
-
 ##### use_mcollective
 Whether or not to use MCollective CLI command. REQUIRES MCOLLECTIVE AND MCOLLECTIVE R10K.
 * Valid options: [ `true`, `false` ]
 * Default: `false`
 
+##### discovery_timeout
+MCollective Ruby discovery timeout. REQUIRES `use_mco_ruby` TO BE `true`.
+* Default: `'10'`
+
 ##### slack_webhook
 Whether or not to use Slack Notifications.
 * Valid options: [ `true`, `false` ]
 * Default: `false`
-
-##### slack_channel
-Slack channel to notify.
-* Default: `'#default'`
-
-##### slack_user
-Slack user to notify as.
-* Default: `'r10k'`
 
 ##### slack_proxy_url
 The proxy URL for Slack if used.
@@ -207,7 +187,7 @@ An Array of environments for r10k to ignore during deployment.
 ##### prefix
 r10k Environment Prefix to use. When set to `repo`, `user`, or `command`, the prefix will be generated from the repo_name, repo_user, or `prefix_command`. Otherwise it will set the prefix to the passed string. `false` disables prefix.
 * Valid Options: [ `repo`, `user`, `command`, `<String_value>`, `false` ]
-* Default: `false`
+* Default: `nil`
 
 ##### prefix_command
 Command to execute that will generate an r10k environment prefix.
@@ -230,3 +210,17 @@ Used to verify the signature on a repo. Currently only supported for Github repo
 ##### repository_events
 Array of webhook events to ignore.
 * Default: `nil`
+
+## Getting Help
+
+* IRC: VoxPupuli has a dedicated channel, `#voxpupuli`, on Freenode where `puppet_webhook` questions can be directed.
+* Mailing Lists: [voxpupuli](https://groups.io/g/voxpupuli)
+* Slack: VoxPupuli has a dedicated Slack Channel, `#voxpupuli`, on  the [Puppet Community](https://slack.puppet.com/) Slack.
+
+## Contributors
+
+A big thank you to all our [Contributor](https://github.com/voxpupuli/puppet_webhook/graphs/contributors)
+
+## License
+
+See LICENSE

--- a/README.md
+++ b/README.md
@@ -37,6 +37,20 @@ NOTE: RPM, DEB, and Arch packages are planned for future releases.
 
 ### Running puppet_webhook
 
+#### Quick Start
+Simply run `# puppet_webhook` after installation to start puppet_webhook in non-daemon mode on your system. This is great for testing the server out.
+
+#### CLI Tool
+The `puppet_webhook` CLI command has several options you can pass it as well.
+
+To see these options run `# puppet_webook -h` in your terminal to see all the options.
+
+#### Start using Rack-based server software
+A `config.ru` file is also packaged with the application to provide users with the ability to start the app using their own rack-based server such as
+unicorn or puma. It will use the defaults passed to it by said server.
+
+#### Service Start
+Once the native packages are built, they will include default systemd and/or sysvinit service files that you can use to start puppet_webhook as well.
 
 ### Configuring puppet_webhook
 
@@ -47,6 +61,23 @@ There are default configuration files included in the application's config direc
 Any configuration option is placed in `/etc/puppet_webhook/server.yml` or `/etc/puppet_webhook/app.yml` will override the default config defined in `APPDIR/config/server.yml` and `APPDIR/config/app.yml`.
 
 #### Configuration options
+
+#### Command-Line Options
+
+* `-h, --help`: Display the default help output.
+* `-d, --debug`: Set logging to debug mode.
+* `-l [LOGFILE], --logfile [LOGFILE]`: Define a logfile to log to.
+* `-p PORT, --port PORT`: Define port to listen on. Default: `8088`
+* `-D, --daemon`: Run WEBrick in Daemon mode.
+* `--pidfile FILE`: Define the PID File for the application's process. Default: `/var/run/puppet_webhook/webhook.pid`
+* `--ssl`: Enable SSL Support.
+* `--ssl-cert FILE`: Specify the SSL cert to use. Pair with `--ssl-key`. Requires `--ssl` option or `ssl_enable: true` in config file.
+* `--ssl-key FILE`: Specify the SSL Private key to use. Pair with `--ssl-cert`. Requires `--ssl` or `ssl_enable: true` in config file.
+* `-c FILE, --configfile FILE`: Specifies a config file to use. Must be a `.yml` file in YAML format.
+
+
+#### Server Configuration File
+The Server configuration file is a YAML formatted file with file extension `.yml` and
 
 #### server.yml
 

--- a/README.md
+++ b/README.md
@@ -38,18 +38,22 @@ NOTE: RPM, DEB, and Arch packages are planned for future releases.
 ### Running puppet_webhook
 
 #### Quick Start
+
 Simply run `# puppet_webhook` after installation to start puppet_webhook in non-daemon mode on your system. This is great for testing the server out.
 
 #### CLI Tool
+
 The `puppet_webhook` CLI command has several options you can pass it as well.
 
 To see these options run `# puppet_webook -h` in your terminal to see all the options.
 
 #### Start using Rack-based server software
+
 A `config.ru` file is also packaged with the application to provide users with the ability to start the app using their own rack-based server such as
 unicorn or puma. It will use the defaults passed to it by said server.
 
 #### Service Start
+
 Once the native packages are built, they will include default systemd and/or sysvinit service files that you can use to start puppet_webhook as well.
 
 ### Configuring puppet_webhook
@@ -77,53 +81,64 @@ Any configuration option is placed in `/etc/puppet_webhook/server.yml` or `/etc/
 
 
 #### Server Configuration File
+
 The Server configuration file is a YAML formatted file with file extension `.yml` and defined with the `-c` or `--configfile`
 command line option. These settings are exclusively for setting server configs and currently will override any command line settings
 passed.
 
-When using the default systemd unit file or SysVInit service file, the server configuration file will default to `/etc/puppet_webhook/server.yml` (Not implemented yet).
+When using the default SystemD unit file or SysVInit service file, the server configuration file will default to `/etc/puppet_webhook/server.yml` (Not implemented yet).
 
 ##### Options
 
 #####`server_type`
+
 Determines if the Webrick server should run in Simple or Daemon mode.     
 * Valid options: [ `simple`, `daemon` ].      
 * Default: `simple` 
 
 ##### `logfile`
+
 Location to write the log file to.
 * Default: `/var/log/puppet_webhook`
 
 ##### `loglevel`
+
 Define the logging level.
 * Default: `WARN`
 
 ##### `pidfile`
+
 Location of the application's PID file
 * Default: `/var/run/puppet_webhook/webhook.pid`
 
 ##### `port`
+
 Port number to bind to.
 * Valid options: Integer between `1024` and `65535`
 * Default: `8088`
 
 ##### `enable_ssl`
+
 Whether or not to enable SSL communication.
 * Valid options: [ `true`, `false` ]
 * Default: `false`
 
 ##### `ssl_verify`
+
 Whether or not to verify the SSL CA/Peer on the certifcate. Set to false if using a self-signed certificate and the CA is not installed locally.
 * Valid options: [ `true`, `false` ]
 * Default: `false`
 
 ##### `ssl_cert`
+
 Path to the public SSL certificate for puppet_webhook. REQUIRED IF `ssl_enable` IS SET TO `true`
 
 ##### `ssl_key`
+
 Path to the SSL Private Key for puppet_webhook. REQUIRED IF `ssl_enable` IS SET TO `true`
 
 #### Application Configuration File
+
 This file stores the configuration for the Application itself. A default configuration file is included in the `APP_ROOT/config/app.yml`.
 
 The SystemD unit and SysVInit service files will use `/etc/puppet_webhook/app.yml` by default (Not implemented yet).
@@ -133,89 +148,107 @@ Currently, the above two locations are the only valid locations for the app.yml 
 ##### Options
 
 ##### `protected`
+
 Whether or not to require authentication when sending to puppet_webhook.
 * Valid options: [ `true`, `false` ]
 * Default: `false`
 
 ##### `user`
+
 User for which the sending application must authenticate with. Required if `protected` is true.
 
 ##### `pass`
+
 Password for which the sending application must authenticate with. Require if `protected` is true.
 
 ##### client_cfg
+
 Mcollective client configuration file.
 * Default: `/var/lib/peadmin/.mcollective`
 
 ##### client_timeout
+
 Mcollective client timeout in seconds.
 * MUST BE A STRING
 * Default: `"120"`
 
 ##### use_mco_ruby
+
 Whether or not to execute MCollective via Ruby Client Library or not. REQUIRES MCOLLECTIVE AND MCOLLECTIVE R10K!
 * Valid options: [ `true`, `false` ]
 * Default: `false`
 
 ##### use_mcollective
+
 Whether or not to use MCollective CLI command. REQUIRES MCOLLECTIVE AND MCOLLECTIVE R10K.
 * Valid options: [ `true`, `false` ]
 * Default: `false`
 
 ##### discovery_timeout
+
 MCollective Ruby discovery timeout. REQUIRES `use_mco_ruby` TO BE `true`.
 * Default: `'10'`
 
 ##### slack_webhook
+
 Whether or not to use Slack Notifications.
 * Valid options: [ `true`, `false` ]
 * Default: `false`
 
 ##### slack_proxy_url
+
 The proxy URL for Slack if used.
 * MUST BE A VALID URL.
 * Default: `nil`
 
 ##### default_branch
+
 The default git branch to use with the r10k Control Repo.
 * Default: `production`
 
 ##### ignore_environment
+
 An Array of environments for r10k to ignore during deployment.
 * Default: []
 
 ##### prefix
+
 r10k Environment Prefix to use. When set to `repo`, `user`, or `command`, the prefix will be generated from the repo_name, repo_user, or `prefix_command`. Otherwise it will set the prefix to the passed string. `false` disables prefix.
 * Valid Options: [ `repo`, `user`, `command`, `<String_value>`, `false` ]
 * Default: `nil`
 
 ##### prefix_command
+
 Command to execute that will generate an r10k environment prefix.
 * Default: ''
 
 ##### r10k_deploy_arguments
+
 r10k command arguments to pass to the `r10k deploy environment` command.
 * Default: `"-pv"`
 
 ##### allow_uppercase
+
 Whether or not to allow uppercase letters in environment names. If false, then puppet_webhook assumes environment names are downcase. If `true`, then puppet_webhook will normalize the environment name.
 * Valid options: [ `true`, `false` ]
 * Default: `true`
 
 ##### github_secret
+
 Used to verify the signature on a repo. Currently only supported for Github repos.
 * MUST BE A VALID OPENSSL `sha1` HASH.
 * Default: `nil`
 
 ##### repository_events
+
 Array of webhook events to ignore.
 * Default: `nil`
 
 ## Getting Help
 
-* IRC: VoxPupuli has a dedicated channel, `#voxpupuli`, on Freenode where `puppet_webhook` questions can be directed.
+* IRC: Vox Pupuli has a dedicated channel, `#voxpupuli`, on Freenode where `puppet_webhook` questions can be directed.
 * Mailing Lists: [voxpupuli](https://groups.io/g/voxpupuli)
-* Slack: VoxPupuli has a dedicated Slack Channel, `#voxpupuli`, on  the [Puppet Community](https://slack.puppet.com/) Slack.
+* Slack: Vox Pupuli has a dedicated Slack Channel, `#voxpupuli`, on  the [Puppet Community](https://slack.puppet.com/) Slack.
 
 ## Contributors
 

--- a/bin/puppet_webhook
+++ b/bin/puppet_webhook
@@ -56,7 +56,7 @@ optparse = OptionParser.new do |opts| # rubocop:disable Metrics/BlockLength
   end
 
   opts.on('-c FILE', '--configfile FILE', 'Specifies a configuration file to use. Not functional yet.') do |arg|
-    options[:config_file] = arg
+    @server_config = arg
   end
 
   opts.separator('')
@@ -71,7 +71,21 @@ end
 
 optparse.parse!
 
-# config_file(File.join(__dir__, '..', 'config', 'server.yml'), '/etc/puppet_webhook/server.yml', options[:config_file])
+if @server_config
+  config_file(@server_config)
+  if settings.respond_to? :server_type=
+    options[:server_type] = WEBrick::Daemon if settings.server_type == 'daemon'
+  end
+  options[:host] = settings.host if settings.respond_to? :host=
+  options[:port] = settings.port if settings.respond_to? :port=
+  options[:pidfile] = settings.pidfile if settings.respond_to? :pidfile=
+  options[:logfile] = settings.logfile if settings.respond_to? :logfile=
+  options[:loglevel] = settings.loglevel if settings.respond_to? :loglevel=
+  ssl_opts[:enable_ssl] = settings.enable_ssl if settings.respond_to? :enable_ssl=
+  ssl_opts[:ssl_verify] = settings.ssl_verify if settings.respond_to? :ssl_verify=
+  ssl_opts[:ssl_cert] = settings.ssl_cert if settings.respond_to? :ssl_cert=
+  ssl_opts[:ssl_key] = settings.enable_ssl if settings.respond_to? :ssl_key=
+end
 
 LOGGER = WEBrick::Log.new(options[:logfile], options[:loglevel])
 

--- a/bin/puppet_webhook
+++ b/bin/puppet_webhook
@@ -55,7 +55,7 @@ optparse = OptionParser.new do |opts| # rubocop:disable Metrics/BlockLength
     ssl_opts[:ssl_key] = OpenSSL::PKey::RSA.new(File.open(arg))
   end
 
-  opts.on('-c FILE', '--configfile FILE', 'Specifies a configuration file to use. Not functional yet.') do |arg|
+  opts.on('-c FILE', '--configfile FILE', 'Specifies a configuration file to use.') do |arg|
     @server_config = arg
   end
 

--- a/lib/helpers/tasks.rb
+++ b/lib/helpers/tasks.rb
@@ -1,9 +1,10 @@
 require 'open3'
 require 'slack-notifier'
 require 'mcollective'
-include MCollective::RPC
 
 module Tasks # rubocop:disable Style/Documentation
+  include MCollective::RPC
+
   def ignore_env?(env)
     list = settings.ignore_environments
     return false if list.nil? || list.empty?

--- a/puppet_webhook.gemspec
+++ b/puppet_webhook.gemspec
@@ -1,5 +1,4 @@
-# rubocop:disable Metrics/BlockLength
-Gem::Specification.new do |spec|
+Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.name = 'puppet_webhook'
   spec.summary = 'Sinatra Webhook Server for Puppet/R10K'
   spec.version = '0.1.0'


### PR DESCRIPTION
Updated the configuration options in the binary file to allow for the definition of a config file for the web server options. At this time, the config file overrides CLI options when they conflict.

Additionally, the README was updated to account for changes since the `0.1.0` release.