### PR TITLE
Async routes

### DIFF
--- a/lib/helpers/tasks.rb
+++ b/lib/helpers/tasks.rb
@@ -47,14 +47,9 @@ module Tasks # rubocop:disable Style/Documentation
   end
 
   def run_command(command)
-    if Open3.respond_to?('capture3')
-      stdout, stderr, exit_status = Open3.capture3(command)
-      message = "triggered: #{command}\n#{stdout}\n#{stderr}"
-    else
-      message = "forked: #{command}"
-      Process.detach(fork { exec "#{command} &" })
-      exit_status = 0
-    end
+    message = "forked: #{command}"
+    Process.detach(fork { exec "#{command} &" })
+    exit_status = 0
     raise "#{stdout}\n#{stderr}" if exit_status != 0
     message
   end

--- a/lib/helpers/tasks.rb
+++ b/lib/helpers/tasks.rb
@@ -48,9 +48,7 @@ module Tasks # rubocop:disable Style/Documentation
 
   def run_command(command)
     message = "forked: #{command}"
-    Process.detach(fork { exec "#{command} &" })
-    exit_status = 0
-    raise "#{stdout}\n#{stderr}" if exit_status != 0
+    exec "#{command} &"
     message
   end
 

--- a/lib/routes/module.rb
+++ b/lib/routes/module.rb
@@ -20,7 +20,7 @@ module Sinatra
 
           module_name = sanitize_input(module_name)
           LOGGER.info("Deploying module #{module_name}")
-          deploy_module(module_name)
+          Process.detach(fork { deploy_module(module_name) })
         end
       end
     end

--- a/lib/routes/payload.rb
+++ b/lib/routes/payload.rb
@@ -61,7 +61,7 @@ module Sinatra
             return 200
           else
             LOGGER.info("Deploying environment #{env}")
-            deploy(env, deleted)
+            Process.detach(fork { deploy(env, deleted) })
           end
         end
       end


### PR DESCRIPTION
Removed open3 calls in the `run_command` method as it was preventing the application from forking system calls. The logging of commands still exists within the application.

Moved the process fork from the `run_command` method into the method call in each POST route. This allows for not only running system calls asynchronously, but also allows for the API calls to run asynchronously.

This solves an issue where Gitlab and Github webhooks expect a response within 10 seconds while an `r10k` or `mco` run could take longer to return.