### PR TITLE
Add support for Bitbucket Server web hook format

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.2
   Exclude:
     - 'vendor/**/*'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ after_script:
 matrix:
   fast_finish: true
   include:
-    - rvm: 2.1.9
+    - rvm: 2.2
       env: CHECK=test
     - rvm: 2.4.2
       env: CHECK=test_and_report_coverage

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ puppet_webhook is a Sinatra-based application receiving REST-based calls to trig
 
 ## Prerequisites
 
-* Ruby 2.1.9 or greater
+* Ruby 2.2 or greater
 * Puppet 4.7.1 or greater
 * r10k gem
 * *Optional*: MCollective and MCollective-r10k (Provides one form of multi-master syncronization)

--- a/lib/parsers/webhook_parser.rb
+++ b/lib/parsers/webhook_parser.rb
@@ -46,12 +46,12 @@ module Sinatra
 
       def bitbucket_webhook?
         # https://confluence.atlassian.com/bitbucket/event-payloads-740262817.html
-        env.key?('HTTP_X_EVENT_KEY') and env.key?('HTTP_X_HOOK_UUID')
+        env.key?('HTTP_X_EVENT_KEY') && env.key?('HTTP_X_HOOK_UUID')
       end
 
       def bitbucketserver_webhook?
         # https://confluence.atlassian.com/bitbucket/event-payloads-740262817.html
-        env.key?('HTTP_X_EVENT_KEY') and env.key?('HTTP_X_REQUEST_ID')
+        env.key?('HTTP_X_EVENT_KEY') && env.key?('HTTP_X_REQUEST_ID')
       end
 
       def tfs_webhook?

--- a/lib/parsers/webhook_parser.rb
+++ b/lib/parsers/webhook_parser.rb
@@ -45,7 +45,7 @@ module Sinatra
 
       def bitbucket_webhook?
         # https://confluence.atlassian.com/bitbucket/event-payloads-740262817.html
-        env.key?('HTTP_X_EVENT_KEY')
+        env.key?('HTTP_X_EVENT_KEY') and env.key?('HTTP_X_HOOK_UUID')
       end
 
       def tfs_webhook?

--- a/puppet_webhook.gemspec
+++ b/puppet_webhook.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.summary = 'Sinatra Webhook Server for Puppet/R10K'
   spec.version = '1.4.0'
   spec.platform = Gem::Platform::RUBY
-  spec.required_ruby_version = '>= 2.1.9'
+  spec.required_ruby_version = '>= 2.2'
   spec.authors = ['Vox Pupuli']
   spec.email = 'voxpupuli@groups.io'
   spec.files = Dir[

--- a/spec/fixtures/bitbucket/update-headers.json
+++ b/spec/fixtures/bitbucket/update-headers.json
@@ -1,3 +1,4 @@
 {
-  "HTTP_X_EVENT_KEY": "repo:push"
+  "HTTP_X_EVENT_KEY": "repo:push",
+  "HTTP_X_HOOK_UUID": "test-uuid"
 }

--- a/spec/fixtures/bitbucketserver/delete.json
+++ b/spec/fixtures/bitbucketserver/delete.json
@@ -1,0 +1,43 @@
+{  
+  "eventKey":"repo:refs_changed",
+  "date":"2017-09-19T09:45:32+1000",
+  "actor":{  
+    "name":"chet",
+    "emailAddress":"ChetRHosey@eaton.com",
+    "id":1,
+    "displayName":"Chet Hosey",
+    "active":true,
+    "slug":"chet",
+    "type":"NORMAL"
+  },
+  "repository":{  
+    "slug":"r10k",
+    "id":84,
+    "name":"puppet-r10k",
+    "scmId":"git",
+    "state":"AVAILABLE",
+    "statusMessage":"Available",
+    "forkable":true,
+    "project":{  
+      "key":"DR",
+      "id":84,
+      "name":"Demo Project",
+      "public":true,
+      "type":"NORMAL"
+    },
+    "public":false
+  },
+  "changes":[  
+    {  
+      "ref":{  
+        "id":"refs/heads/feature_branch",
+        "displayId":"feature_branch",
+        "type":"BRANCH"
+      },
+      "refId":"refs/heads/feature_branch",
+      "fromHash":"ecddabb624f6f5ba43816f5926e580a5f680a932",
+      "toHash":"178864a7d521b6f5e720b386b2c2b0ef8563e0dc",
+      "type":"DELETE"
+    }
+  ]
+}

--- a/spec/fixtures/bitbucketserver/update-headers.json
+++ b/spec/fixtures/bitbucketserver/update-headers.json
@@ -1,0 +1,4 @@
+{
+  "HTTP_X_EVENT_KEY": "repo:push",
+  "HTTP_X_REQUEST_ID": "1"
+}

--- a/spec/fixtures/bitbucketserver/update.json
+++ b/spec/fixtures/bitbucketserver/update.json
@@ -1,0 +1,43 @@
+{  
+  "eventKey":"repo:refs_changed",
+  "date":"2017-09-19T09:45:32+1000",
+  "actor":{  
+    "name":"chet",
+    "emailAddress":"ChetRHosey@eaton.com",
+    "id":1,
+    "displayName":"Chet Hosey",
+    "active":true,
+    "slug":"chet",
+    "type":"NORMAL"
+  },
+  "repository":{  
+    "slug":"r10k",
+    "id":84,
+    "name":"puppet-r10k",
+    "scmId":"git",
+    "state":"AVAILABLE",
+    "statusMessage":"Available",
+    "forkable":true,
+    "project":{  
+      "key":"DR",
+      "id":84,
+      "name":"Demo Project",
+      "public":true,
+      "type":"NORMAL"
+    },
+    "public":false
+  },
+  "changes":[  
+    {  
+      "ref":{  
+        "id":"refs/heads/feature_branch",
+        "displayId":"feature_branch",
+        "type":"BRANCH"
+      },
+      "refId":"refs/heads/feature_branch",
+      "fromHash":"ecddabb624f6f5ba43816f5926e580a5f680a932",
+      "toHash":"178864a7d521b6f5e720b386b2c2b0ef8563e0dc",
+      "type":"UPDATE"
+    }
+  ]
+}

--- a/spec/unit/parsers/webhook_json_parser_spec.rb
+++ b/spec/unit/parsers/webhook_json_parser_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Sinatra::Parsers::WebhookJsonParser do
-  services = %w[stash bitbucket github gitlab tfs]
+  services = %w[stash bitbucket bitbucketserver github gitlab tfs]
   let(:result) { subject.call(payload) }
   services.each do |service|
     context "when payload is from #{service}" do


### PR DESCRIPTION
According to [a comment from Atlassian](https://community.atlassian.com/t5/Bitbucket-questions/Why-Server-Webhook-payload-are-different-from-Cloud/qaq-p/799017), the payloads are different for Bitbucket cloud and Bitbucket server.

This PR makes the "bitbucket" detection more selective, so that it doesn't try to handle requests from Bitbucket Server.

It also adds tests and code to handle requests following the Bitbucket Server format.

This was tested against Bitbucket Server 5.7.1.