### PR TITLE
Stray payload reference

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.2
   Exclude:
     - 'vendor/**/*'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ after_script:
 matrix:
   fast_finish: true
   include:
-    - rvm: 2.1.9
+    - rvm: 2.2.0
       env: CHECK=test
     - rvm: 2.4.2
       env: CHECK=test_and_report_coverage

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ puppet_webhook is a Sinatra-based application receiving REST-based calls to trig
 
 ## Prerequisites
 
-* Ruby 2.1.9 or greater
-* Puppet 4.7.1 or greater
+* Ruby 2.2.0 or greater
+* Puppet 5.0.0 or greater
 * r10k gem
 * *Optional*: MCollective and MCollective-r10k (Provides one form of multi-master syncronization)
     * Currently Mcollective-r10k is only available from [puppet-r10k](https://github.com/voxpupuli/puppet-r10k)

--- a/lib/routes/payload.rb
+++ b/lib/routes/payload.rb
@@ -6,7 +6,6 @@ module Sinatra
     module Payload
       def self.registered(puppet_webhook)
         puppet_webhook.post '/payload' do # rubocop:disable Metrics/BlockLength
-          LOGGER.info "parsed payload contained: #{payload}"
           protected! if settings.protected
           request.body.rewind # in case someone already read it
 

--- a/puppet_webhook.gemspec
+++ b/puppet_webhook.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.summary = 'Sinatra Webhook Server for Puppet/R10K'
   spec.version = '1.4.0'
   spec.platform = Gem::Platform::RUBY
-  spec.required_ruby_version = '>= 2.1.9'
+  spec.required_ruby_version = '>= 2.2.0'
   spec.authors = ['Vox Pupuli']
   spec.email = 'voxpupuli@groups.io'
   spec.files = Dir[


### PR DESCRIPTION
Commit 420e33c removed the `payload` function, so execution fails when we try to log it.