### PR TITLE
Ensure that loglevel is using the const value

### DIFF
--- a/bin/puppet_webhook
+++ b/bin/puppet_webhook
@@ -87,7 +87,7 @@ if @server_config
   ssl_opts[:ssl_key] = settings.enable_ssl if settings.respond_to? :ssl_key=
 end
 
-LOGGER = WEBrick::Log.new(options[:logfile], options[:loglevel])
+LOGGER = WEBrick::Log.new(options[:logfile], Object.const_get("WEBrick::Log::#{options[:loglevel]}"))
 
 webrick_opts = {
   Host: options[:host],


### PR DESCRIPTION
When loglevel is set in server.yml, it is passed in as a String, but
WEBrick::Log @loglevel requires an Integer. To resolve this, when
LOGGER is set, it will now grab the value of the constant that is
associated with the loglevel and pass that value in (which is an integer).