### PR TITLE
Change webrick log constants to strings to match conf file

### DIFF
--- a/bin/puppet_webhook
+++ b/bin/puppet_webhook
@@ -10,7 +10,7 @@ options = {
   host: '0.0.0.0',
   port: '8088',
   logfile: $stderr,
-  loglevel: WEBrick::Log::WARN,
+  loglevel: 'WARN',
   server_type: WEBrick::SimpleServer
 }
 
@@ -23,7 +23,7 @@ optparse = OptionParser.new do |opts| # rubocop:disable Metrics/BlockLength
 '
 
   opts.on('-d', '--debug', 'Display or log messages.') do
-    options[:loglevel] = WEBrick::Log::DEBUG
+    options[:loglevel] = 'DEBUG'
   end
 
   opts.on('-l [LOGFILE]', '--logfile [LOGFILE]',


### PR DESCRIPTION
Setting the constant for `WEBrick::Log` in the binfile will cause an error as the LOGGER constant is set by taking a string and getting the constant from that. 