### PR TITLE
Fix a http body param bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,22 @@
-*.gem
-webhook.lock
-.ruby_version
-logs/*.log
-.idea/
-coverage
-.byebug_history
-vendor/
+# Ruby files
 .bundle/
+.byebug_history
+*.gem
+coverage
+webhook.lock
+vendor/
+
+# App Ignores
+logs/*.log
+config/config.yml
+
+# Editor Tools
+.ruby_version
+.tool-versions
+.idea/
 .vscode/
+
+# YARDoc Files
 .yardoc/
 doc/
 public/
-config/config.yml

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,4 +265,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/app/controllers/api/v1/r10k/environment_controller.rb
+++ b/app/controllers/api/v1/r10k/environment_controller.rb
@@ -6,7 +6,7 @@ class Api
         # POST: /payloads
         post %r{\/(payload|api\/v1\/r10k\/environment)} do
           protected! if APP_CONFIG.protected
-          data = PuppetWebhook::Parsers.new(headers, body).params
+          data = PuppetWebhook::Parsers.new(headers, req_body).params
           prefix = get_prefix(data)
           branch = get_branch(data)
           env = get_env(branch, prefix)
@@ -36,7 +36,7 @@ class Api
           headers
         end
 
-        def body
+        def req_body
           request.body.rewind
           request.body.read
         end


### PR DESCRIPTION
Fixed a bug where one of the parameters sent to a method was named
`body`. This was an issue as the `body` method is built into Rack and
was causing the application to become confused are fail on API calls.

Updated and organized .gitignore.

Gemfile.lock  updated as part of a bundle install