### PR TITLE
Remove gemnasium badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 [![Test Coverage](https://api.codeclimate.com/v1/badges/f4f083a54a85f4cc97f0/test_coverage)](https://codeclimate.com/github/voxpupuli/puppet_webhook/test_coverage)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/f73823762ec947889866c63c4ea47540)](https://www.codacy.com/app/VoxPupuli/puppet_webhook?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=voxpupuli/puppet_webhook&amp;utm_campaign=Badge_Grade)
 [![Coverage Status](https://coveralls.io/repos/github/voxpupuli/puppet_webhook/badge.svg?branch=master)](https://coveralls.io/github/voxpupuli/puppet_webhook?branch=master)
-[![Dependency Status](https://gemnasium.com/badges/github.com/voxpupuli/puppet_webhook.svg)](https://gemnasium.com/github.com/voxpupuli/puppet_webhook)
 
 ## What is puppet_webhook
 


### PR DESCRIPTION
> Gemnasium has been acquired by GitLab in January 2018. Since May 15, 2018, the services provided by Gemnasium are no longer available.
https://docs.gitlab.com/ee/user/project/import/gemnasium.html