### PR TITLE
Fix a parser issue with the module endpoint

### DIFF
--- a/app/controllers/api/v1/r10k/environment_controller.rb
+++ b/app/controllers/api/v1/r10k/environment_controller.rb
@@ -30,19 +30,6 @@ class Api
 
         private
 
-        def headers
-          headers = {}
-          request.env.each do |k, v|
-            headers[k.to_s] = v.to_s if k =~ %r{^([A-Z]|_)+$}
-          end
-          headers
-        end
-
-        def req_body
-          request.body.rewind
-          request.body.read
-        end
-
         def get_prefix(data)
           case APP_CONFIG.prefix
           when 'repo'

--- a/app/controllers/api/v1/r10k/module_controller.rb
+++ b/app/controllers/api/v1/r10k/module_controller.rb
@@ -8,8 +8,7 @@ class Api
         # POST: /module
         post %r{\/(module|api\/v1\/r10k\/module)} do
           protected! if APP_CONFIG.protected
-          request.body.rewind
-          data = PuppetWebhook::Parsers.new(request).params
+          data = PuppetWebhook::Parsers.new(headers, req_body).params
 
           ModuleController.helpers R10kHelpers
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -74,4 +74,17 @@ class ApplicationController < Sinatra::Base
                                                   {}
                                                 end
   end
+
+  def headers
+    headers = {}
+    request.env.each do |k, v|
+      headers[k.to_s] = v.to_s if k =~ %r{^([A-Z]|_)+$}
+    end
+    headers
+  end
+
+  def req_body
+    request.body.rewind
+    request.body.read
+  end
 end


### PR DESCRIPTION
There was an issue in the code where the Headers were not getting sent to the parser on the module endpoint causing the parser to error out as it was missing an argument. Since both the environment and module endpoints need this data, I moved the `req_body` and `headers` methods in to `ApplicationController`