### PR TITLE
Sidekiq: Set concurrency to 1

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,8 +1,2 @@
 ---
-:concurrency: 5
-development:
-  :concurrency: 5
-staging:
-  :concurrency: 10
-production:
-  :concurrency: 40
+:concurrency: 1


### PR DESCRIPTION
r10k isn't able to run in parallel, at least for module deployments via
ssh. Setting this 1 one queues jobs and just executes one after another.

This fixes https://github.com/voxpupuli/puppet_webhook/issues/155