### PR TITLE
Add redis settings for sidekiq

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,20 @@ type: Boolean
 description: Allow uppercase within the name of the module or environment passed to the API.
 default: true
 
+### Redis/Sidekiq Settings
+
+#### `redis_url`
+
+type: String
+description: The Redis connection url to use to connect to your Redis database.
+default: `redis://localhost:6379/0`
+
+#### `redis_password`
+
+type: String
+description: The password to authenticate to Redis with.
+default: `nil`
+
 ### Logging Settings
 
 #### `loglevel`

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -12,6 +12,10 @@ development:
   ignore_environments: []
   allow_uppercase: true
 
+  # Redis
+  redis_url: "redis://localhost:6379/0"
+  redis_password: password
+
   # Logging
   loglevel: debug
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -4,6 +4,20 @@ require 'sidekiq'
 require 'sidekiq/web'
 require './config/environment'
 
+Sidekiq.configure_server do |config|
+  config.redis = {
+    url: APP_CONFIG.redis_url ||= 'redis://localhost:6370/0',
+    password: APP_CONFIG.redis_password ||= nil
+  }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = {
+    url: APP_CONFIG.redis_url ||= 'redis://localhost:6370/0',
+    password: APP_CONFIG.redis_password ||= nil
+  }
+end
+
 Sidekiq::Web.use(Rack::Auth::Basic) do |user, password|
   # Protect against timing attacks:
   # - See https://codahale.com/a-lesson-in-timing-attacks/


### PR DESCRIPTION
Update the sidekiq initializer to include settings to configure the Redis host, port, and password.

Closes #159
